### PR TITLE
Feat add request route state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2289,14 +2289,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2311,20 +2309,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2441,8 +2436,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2454,7 +2448,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2469,7 +2462,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2477,14 +2469,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2503,7 +2493,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2584,8 +2573,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2597,7 +2585,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2719,7 +2706,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/aurelia-helpers.ts
+++ b/src/aurelia-helpers.ts
@@ -1,8 +1,0 @@
-import { NavigationInstruction } from 'aurelia-router';
-
-export const getInstructionUrl = (instruction: NavigationInstruction): string => {
-  const queryString = instruction.queryString
-    ? `?${instruction.queryString}`
-    : '';
-  return instruction.fragment + queryString;
-};

--- a/src/aurelia-helpers.ts
+++ b/src/aurelia-helpers.ts
@@ -1,0 +1,8 @@
+import { NavigationInstruction } from 'aurelia-router';
+
+export const getInstructionUrl = (instruction: NavigationInstruction): string => {
+  const queryString = instruction.queryString
+    ? `?${instruction.queryString}`
+    : '';
+  return instruction.fragment + queryString;
+};

--- a/src/open-id-connect-authorize-step.ts
+++ b/src/open-id-connect-authorize-step.ts
@@ -29,7 +29,12 @@ export default class OpenIdConnectAuthorizeStep implements PipelineStep {
     if (this.requiresRole(navigationInstruction, OpenIdConnectRoles.Authenticated)) {
       if (user === null) {
         this.logger.debug('Requires authenticated role.');
-        const redirect = new Redirect(this.configuration.unauthorizedRedirectRoute);
+        // capture the route to which the user was originally navigating (e.g. person/1)
+        const loginRedirectRoute = encodeURIComponent(this.getInstructionUrl(navigationInstruction));
+
+        // store that route in a query string when we redirect to the unauthorizedRedirectRoute
+        const redirect = new Redirect(
+          this.configuration.unauthorizedRedirectRoute + '?loginRedirectRoute=' + loginRedirectRoute);
         return next.cancel(redirect);
       }
     }
@@ -48,5 +53,10 @@ export default class OpenIdConnectAuthorizeStep implements PipelineStep {
       instruction.config.settings !== undefined &&
       instruction.config.settings.roles !== undefined &&
       instruction.config.settings.roles.includes(role));
+  }
+
+  private getInstructionUrl(instruction: NavigationInstruction): string {
+    const queryString = instruction.queryString ? `?${instruction.queryString}` : '';
+    return instruction.fragment + queryString;
   }
 }

--- a/src/open-id-connect-authorize-step.ts
+++ b/src/open-id-connect-authorize-step.ts
@@ -6,6 +6,7 @@ import {
   Redirect,
 } from 'aurelia-router';
 import { UserManager } from 'oidc-client';
+import { getInstructionUrl } from './aurelia-helpers';
 import OpenIdConnectConfigurationManager from './open-id-connect-configuration-manager';
 import OpenIdConnectLogger from './open-id-connect-logger';
 import OpenIdConnectRoles from './open-id-connect-roles';
@@ -30,11 +31,12 @@ export default class OpenIdConnectAuthorizeStep implements PipelineStep {
       if (user === null) {
         this.logger.debug('Requires authenticated role.');
         // capture the route to which the user was originally navigating (e.g. person/1)
-        const loginRedirectRoute = encodeURIComponent(this.getInstructionUrl(navigationInstruction));
+        const loginRedirectRoute = encodeURIComponent(getInstructionUrl(navigationInstruction));
 
         // store that route in a query string when we redirect to the unauthorizedRedirectRoute
         const redirect = new Redirect(
           this.configuration.unauthorizedRedirectRoute + '?loginRedirectRoute=' + loginRedirectRoute);
+
         return next.cancel(redirect);
       }
     }
@@ -53,10 +55,5 @@ export default class OpenIdConnectAuthorizeStep implements PipelineStep {
       instruction.config.settings !== undefined &&
       instruction.config.settings.roles !== undefined &&
       instruction.config.settings.roles.includes(role));
-  }
-
-  private getInstructionUrl(instruction: NavigationInstruction): string {
-    const queryString = instruction.queryString ? `?${instruction.queryString}` : '';
-    return instruction.fragment + queryString;
   }
 }

--- a/src/open-id-connect-constants.ts
+++ b/src/open-id-connect-constants.ts
@@ -1,3 +1,3 @@
-// Consider using typescript type annotations 
+// Consider using typescript type annotations
 // instead of constant values for object property access.
-export const LoginRedirectKey = "loginRedirect";
+export const LoginRedirectKey = 'loginRedirect';

--- a/src/open-id-connect-constants.ts
+++ b/src/open-id-connect-constants.ts
@@ -1,0 +1,3 @@
+// Consider using typescript type annotations 
+// instead of constant values for object property access.
+export const LoginRedirectKey = "loginRedirect";

--- a/src/open-id-connect-navigation-strategies.ts
+++ b/src/open-id-connect-navigation-strategies.ts
@@ -2,6 +2,7 @@ import { autoinject } from 'aurelia-framework';
 import { NavigationInstruction } from 'aurelia-router';
 import { UserManager } from 'oidc-client';
 import OpenIdConnectConfigurationManager from './open-id-connect-configuration-manager';
+import { LoginRedirectKey } from './open-id-connect-constants';
 import OpenIdConnectLogger from './open-id-connect-logger';
 
 // TODO: Move some of the route-definition logic from
@@ -23,16 +24,14 @@ export default class OpenIdConnectNavigationStrategies {
 
     let redirectRoute = this.openIdConnectConfiguration.loginRedirectRoute;
 
-    // returns the resolved redirectRoute.
     const callbackHandler = async () => {
       const args: any = {};
       const user = await this.userManager.signinRedirectCallback(args);
 
       // The state is not persisted with the rest of the user.
       // This callback is the only place we will be able to capture the state.
-      // If the state is set, it contains the redirect route.
-      if (user.state) {
-        redirectRoute = user.state;
+      if (user.state && user.state[LoginRedirectKey]) {
+        redirectRoute = user.state[LoginRedirectKey];
       }
     };
 

--- a/src/open-id-connect-navigation-strategies.ts
+++ b/src/open-id-connect-navigation-strategies.ts
@@ -20,14 +20,20 @@ export default class OpenIdConnectNavigationStrategies {
     private $window: Window) { }
 
   public async signInRedirectCallback(instruction: NavigationInstruction): Promise<any> {
+
+    let redirectRoute = this.openIdConnectConfiguration.loginRedirectRoute;
+
+    // returns the resolved redirectRoute.
     const callbackHandler = async () => {
       const args: any = {};
-      return this.userManager.signinRedirectCallback(args).then((user) => {
-        // The state is not persisted with the rest of the user.
-        // The resolve callback is the only place you will be able to capture that state.
-        // When the state is set, redirect to this request route.
-        this.$window.location.assign(user.state || this.openIdConnectConfiguration.loginRedirectRoute);
-      });
+      const user = await this.userManager.signinRedirectCallback(args);
+
+      // The state is not persisted with the rest of the user.
+      // This callback is the only place we will be able to capture the state.
+      // If the state is set, it contains the redirect route.
+      if (user.state) {
+        redirectRoute = user.state;
+      }
     };
 
     const navigationInstruction = () => {
@@ -35,7 +41,7 @@ export default class OpenIdConnectNavigationStrategies {
       // because the former adds the route to the web browser's history,
       // and that controls what will load on a page refresh.
       // See https://github.com/aurelia-contrib/aurelia-open-id-connect/issues/46
-      this.$window.location.assign(this.openIdConnectConfiguration.loginRedirectRoute);
+      this.$window.location.assign(redirectRoute);
     };
 
     return this.runHandlerAndCompleteNavigationInstruction(
@@ -52,6 +58,9 @@ export default class OpenIdConnectNavigationStrategies {
     const navigationInstruction = () => {
       // This happens in a child iframe.
       instruction.config.redirect = this.openIdConnectConfiguration.loginRedirectRoute;
+
+      // TODO: Consider redirecting the parent window 
+      // to the loginRedirectRoute when the silent sign in completes.
     };
 
     return this.runHandlerAndCompleteNavigationInstruction(
@@ -63,9 +72,7 @@ export default class OpenIdConnectNavigationStrategies {
 
     const callbackHandler = async () => {
       const args: any = {};
-      return this.userManager.signoutRedirectCallback(args).then(() => {
-        this.$window.location.assign(this.openIdConnectConfiguration.logoutRedirectRoute);
-      });
+      return this.userManager.signoutRedirectCallback(args);
     };
 
     const navigationInstruction = () => {
@@ -84,6 +91,8 @@ export default class OpenIdConnectNavigationStrategies {
     try {
       this.logger.debug('Handling the response from the Identity Provider');
       await callbackHandler();
+      this.logger.debug('Redirecting on authorization success');
+      navigationInstruction();
     } catch (err) {
       this.logger.debug('Redirecting on authorization error');
       navigationInstruction();

--- a/src/open-id-connect-navigation-strategies.ts
+++ b/src/open-id-connect-navigation-strategies.ts
@@ -58,7 +58,7 @@ export default class OpenIdConnectNavigationStrategies {
       // This happens in a child iframe.
       instruction.config.redirect = this.openIdConnectConfiguration.loginRedirectRoute;
 
-      // TODO: Consider redirecting the parent window 
+      // TODO: Consider redirecting the parent window
       // to the loginRedirectRoute when the silent sign in completes.
     };
 

--- a/src/open-id-connect-user-block.ts
+++ b/src/open-id-connect-user-block.ts
@@ -6,7 +6,7 @@ import OpenIdConnect from './open-id-connect';
 @customElement('open-id-connect-user-block')
 export default class {
 
-  protected user: User | null = null;
+  public user: User | null = null;
 
   public get isLoggedIn(): boolean {
     return this.user !== null && this.user !== undefined;

--- a/src/open-id-connect.ts
+++ b/src/open-id-connect.ts
@@ -29,7 +29,7 @@ export default class OpenIdConnect {
   public async login(args: any = {}): Promise<void> {
 
     const loginRedirectValue = this.router.currentInstruction.queryParams[LoginRedirectKey];
-    if(loginRedirectValue) {
+    if (loginRedirectValue) {
       args.data = { ...args.data };
       args.data[LoginRedirectKey] = loginRedirectValue;
     }

--- a/src/open-id-connect.ts
+++ b/src/open-id-connect.ts
@@ -1,9 +1,9 @@
 import { autoinject } from 'aurelia-framework';
 import { Router, RouterConfiguration } from 'aurelia-router';
 import { User, UserManager, UserManagerEvents } from 'oidc-client';
-import { getInstructionUrl } from './aurelia-helpers';
 import { UserManagerEventHandler, UserManagerEventsAction } from './internal-types';
 import OpenIdConnectConfigurationManager from './open-id-connect-configuration-manager';
+import { LoginRedirectKey } from './open-id-connect-constants';
 import OpenIdConnectLogger from './open-id-connect-logger';
 import OpenIdConnectRouting from './open-id-connect-routing';
 
@@ -27,17 +27,13 @@ export default class OpenIdConnect {
   }
 
   public async login(args: any = {}): Promise<void> {
-    const instruction = this.router.currentInstruction;
-    const redirectUrl = instruction.queryParams.loginRedirectRoute || getInstructionUrl(instruction);
 
-    if (redirectUrl && args.data) {
-      const message
-        = 'The login method received an args object with an args.data value.'
-        + 'That value will be overwritten by the loginRedirectRoute parameter in the address bar.';
-      this.logger.warn(message);
+    const loginRedirectValue = this.router.currentInstruction.queryParams[LoginRedirectKey];
+    if(loginRedirectValue) {
+      args.data = { ...args.data };
+      args.data[LoginRedirectKey] = loginRedirectValue;
     }
 
-    args.data = redirectUrl;
     await this.userManager.signinRedirect(args);
   }
 

--- a/src/open-id-connect.ts
+++ b/src/open-id-connect.ts
@@ -1,5 +1,5 @@
 import { autoinject } from 'aurelia-framework';
-import { Router, RouterConfiguration } from 'aurelia-router';
+import { NavigationInstruction, Router, RouterConfiguration } from 'aurelia-router';
 import { User, UserManager, UserManagerEvents } from 'oidc-client';
 import { UserManagerEventHandler, UserManagerEventsAction } from './internal-types';
 import OpenIdConnectConfigurationManager from './open-id-connect-configuration-manager';
@@ -26,6 +26,8 @@ export default class OpenIdConnect {
   }
 
   public async login(args: any = {}): Promise<void> {
+    const instruction = this.router.currentInstruction;
+    const redirectUrl = instruction.queryParams.loginRedirectRoute || this.getInstructionUrl(instruction);
     await this.userManager.signinRedirect(args);
   }
 
@@ -70,5 +72,10 @@ export default class OpenIdConnect {
     this.addOrRemoveHandler('addUserLoaded', () => this.getUser().then(callback));
     this.addOrRemoveHandler('addUserUnloaded', () => this.getUser().then(callback));
     return this.getUser().then(callback);
+  }
+
+  private getInstructionUrl(instruction: NavigationInstruction): string {
+    const queryString = instruction.queryString ? `?${instruction.queryString}` : '';
+    return instruction.fragment + queryString;
   }
 }

--- a/test/open-id-connect-authorize-step.spec.ts
+++ b/test/open-id-connect-authorize-step.spec.ts
@@ -63,7 +63,7 @@ describe('open-id-connect-authorize-step', () => {
         // act
         await authorizationStep.run(navigationInstruction, next);
         // assert
-        sinon.assert.calledWith(next.cancel, new Redirect(unauthRedirectRoute));
+        sinon.assert.calledWith(next.cancel, new Redirect(unauthRedirectRoute + '?loginRedirectRoute=undefined'));
       });
 
       it(`should NOT redirect to ${unauthRedirectRoute} if user is not null`, async () => {

--- a/test/open-id-connect-navigation-filter.spec.ts
+++ b/test/open-id-connect-navigation-filter.spec.ts
@@ -17,6 +17,24 @@ describe('open-id-connect-navigation-filter', () => {
   const filter = new OpenIdConnectNavigationFilter();
 
   context('toView', () => {
+    [undefined, null].forEach((settingsValue) => {
+      it(`should include all navModels that have ${settingsValue} settings `, () => {
+        // arrange
+        const user = {} as any;
+        const total = 5;
+        const navModels = createNavModelsWithEmptySettings(total)
+          .map((navModel: NavModel, index: number) => {
+            navModel.settings = settingsValue;
+            return navModel;
+          });
+
+        // act
+        const result = filter.toView(navModels, user);
+        // assert
+        assert.equal(result.length, total);
+      });
+    });
+
     [undefined, null].forEach((rolesValue) => {
       it(`should include all navModels that have ${rolesValue} roles `, () => {
         // arrange

--- a/test/open-id-connect-navigation-strategies.spec.ts
+++ b/test/open-id-connect-navigation-strategies.spec.ts
@@ -92,4 +92,26 @@ describe('open-id-connect-navigation-strategies', () => {
       });
     });
   });
+
+  context('when user state contains loginRedirect', () => {
+    afterEach(() => {
+      userManager.signinRedirectCallback.reset();
+    });
+
+    it('should assign loginRedirect to window.location', async () => {
+      // arrange
+      const expected = 'some-login-redirect-value';
+      userManager.signinRedirectCallback.resolves({
+        state: {
+          loginRedirect: expected,
+        },
+      });
+
+      // act
+      await strategies.signInRedirectCallback(instruction);
+
+      // assert
+      sinon.assert.calledWith($window.location.assign, expected);
+    });
+  });
 });

--- a/test/open-id-connect-navigation-strategies.spec.ts
+++ b/test/open-id-connect-navigation-strategies.spec.ts
@@ -27,6 +27,9 @@ describe('open-id-connect-navigation-strategies', () => {
   const logoutRedirectRoute = 'logout';
   sinon.stub(configuration, 'logoutRedirectRoute').get(() => logoutRedirectRoute);
 
+  userManager.signinRedirectCallback = sinon.stub().resolves({});
+  userManager.signoutRedirectCallback = sinon.stub().resolves();
+
   instruction.config = {};
 
   const strategies = new OpenIdConnectNavigationStrategies(

--- a/test/open-id-connect-routing.spec.ts
+++ b/test/open-id-connect-routing.spec.ts
@@ -45,6 +45,7 @@ describe('open-id-connect-routing', () => {
     logger);
 
   context('configureRouter', () => {
+    let navigationStrategy: any;
 
     const getMapRouteArgument = (route: string) => (routerConfiguration.mapRoute as sinon.SinonStub)
       .getCalls()
@@ -56,8 +57,6 @@ describe('open-id-connect-routing', () => {
     });
 
     context('redirect_uri', () => {
-
-      let navigationStrategy: any;
 
       before(() => {
         const arg = getMapRouteArgument(signInPath);
@@ -113,11 +112,29 @@ describe('open-id-connect-routing', () => {
     });
 
     context('post_logout_redirect_uri', () => {
+
+      before(() => {
+        const arg = getMapRouteArgument(signOutPath);
+        navigationStrategy = arg.navigationStrategy;
+      });
+
       it('should map route for the configured path', () => {
         // assert
         sinon.assert.calledWith(
           routerConfiguration.mapRoute,
           sinon.match.has('route', signOutPath));
+      });
+
+      it('should use signout redirect strategy', () => {
+        // arrange
+        openIdConnectNavigationStrategies.signOutRedirectCallback.reset();
+
+        // act
+        navigationStrategy({});
+
+        // assert
+        sinon.assert.calledOnce(
+          openIdConnectNavigationStrategies.signOutRedirectCallback);
       });
     });
   });

--- a/test/open-id-connect.spec.ts
+++ b/test/open-id-connect.spec.ts
@@ -67,14 +67,64 @@ describe('open-id-connect', () => {
       // assert
       sinon.assert.calledOnce(userManager.signinRedirect);
     });
+
+    it('should pass data.loginRedirect to this.userManager.signinRedirect if instruction has queryParam', async () => {
+      // arrange
+      const expected = 'the-login-redirect-data-query-param-value';
+      router.currentInstruction.queryParams.loginRedirect = expected;
+      // act
+      await openIdConnect.login();
+      // assert
+      sinon.assert.calledWith(userManager.signinRedirect, {
+        data: {
+          loginRedirect: expected,
+        },
+      });
+    });
   });
 
   context('logout', () => {
+
+    beforeEach(() => {
+      userManager.signoutRedirect.reset();
+    });
+
     it('should call this.userManager.signoutRedirect', async () => {
       // act
       await openIdConnect.logout();
       // assert
       sinon.assert.calledOnce(userManager.signoutRedirect);
+    });
+
+    const noEndSessionMsg = 'no end session endpoint';
+    it(`should not rethrow if this.userManager.signoutRedirect throws a ${noEndSessionMsg} error`, async () => {
+      // arrange
+      const expected = new Error(noEndSessionMsg);
+      userManager.signoutRedirect.throwsException(expected);
+
+      // act
+      await openIdConnect.logout();
+
+      // assert
+      sinon.assert.calledOnce(userManager.signoutRedirect);
+    });
+
+    it('should rethrow if this.userManager.signoutRedirect throws an error', async () => {
+      // arrange
+      const expected = new Error('expected error');
+      userManager.signoutRedirect.throwsException(expected);
+
+      // act
+      try {
+        await openIdConnect.logout();
+      } catch (ex) {
+        if (ex === expected) {
+          return;
+        }
+      }
+
+      // assert
+      assert.fail('should have thrown');
     });
   });
 

--- a/test/open-id-connect.spec.ts
+++ b/test/open-id-connect.spec.ts
@@ -1,4 +1,4 @@
-import { Router, RouterConfiguration } from 'aurelia-router';
+import { NavigationInstruction, Router, RouterConfiguration } from 'aurelia-router';
 import { assert } from 'chai';
 import { UserManager } from 'oidc-client';
 import sinon = require('sinon');
@@ -16,6 +16,9 @@ describe('open-id-connect', () => {
   const userManager = sinon.createStubInstance(UserManager);
   const router = sinon.createStubInstance(Router);
   const configurationManager = sinon.createStubInstance(OpenIdConnectConfigurationManager);
+  const navigationInstruction = sinon.createStubInstance(NavigationInstruction);
+  navigationInstruction.queryParams = sinon.stub();
+  router.currentInstruction = navigationInstruction;
 
   const events = {
     addUserLoaded: sinon.stub(),


### PR DESCRIPTION
@gerbendekker This is a second attempt at resolving #49 after my first failed merge of https://github.com/aurelia-contrib/aurelia-open-id-connect/pull/51. A review by you would be welcome. 

* [x] Compare this PR's implementation with the [OpenID Connect Spec](http://openid.net/specs/openid-connect-core-1_0.html). Add notes to this PR's conversation about how well its implementation matches the spec.
* [x] Look at how oidc-client.js uses state and see how that meshes with what the requirement for #49.
* [x] Look at the pros and cons of storing application state in the `state` parameter instead of in other storage locations such as local storage or a cookie.
* [x] Bring the test coverage for this PR up to 100% on `npm run test`.
* [x] Document a manual acceptance test for this PR's feature and run that tests manually in one of the https://github.com/aurelia-contrib/aurelia-open-id-connect-demos applications.

---
**It does seem appropriate to maintain application state in the OpenID Connect authentication request's `state` parameter.**

The [OpenID Connect specification says this of the `state` parameter](http://openid.net/specs/openid-connect-core-1_0.html#AuthRequest): 

> Opaque value **used to maintain state between the request and the callback**. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie. 

The oidc-client-js library now accepts [either a `data` or a `state` parameter](https://github.com/IdentityModel/oidc-client-js/blob/63fae547282b44597caced6540466ec7ff6a948e/src/OidcClient.js#L43-L46), and uses its value [as part of the sign in request state value](https://github.com/IdentityModel/oidc-client-js/blob/63fae547282b44597caced6540466ec7ff6a948e/src/SigninRequest.js#L42). 

**Is this the most appropriate location to store state though?**

The concern right now with using `args.data` is that our `OpenIdConnect.login((args)` method accepts an `args` parameter that could include a `data` property. In that case, if we store the `redirectUrl` in the `data` property, we will overwrite the caller's value.

One way to solve that problem is to warn the caller with something like this:
```
public async login(args: any = {}): Promise<void> {
  const instruction = this.router.currentInstruction;
  const redirectUrl = instruction.queryParams.loginRedirectRoute || getInstructionUrl(instruction);

  if (redirectUrl && args.data) {
    const message
      = 'The login method received an args object with an args.data value.'
      + 'That value will be overwritten by the loginRedirectRoute parameter in the address bar.';
    this.logger.warn(message);
  }

  args.data = redirectUrl;
  await this.userManager.signinRedirect(args);
}
```
Another way to handle that is to concatenate our `loginRedirectRoute` value to the `data`, and then strip that value when we read the `user.state` later. 

After the authentication request completes, the `data` value is only available via the return value from `UserManager.signinRedirectCallback`. We do not expose that return value to the client application, so it is not necessary to consider how the client application might make use of a value it cannot access. 