### PR TITLE
 authorize-step should also ensure user session is not expired

### DIFF
--- a/src/open-id-connect-authorize-step.ts
+++ b/src/open-id-connect-authorize-step.ts
@@ -29,7 +29,7 @@ export default class OpenIdConnectAuthorizeStep implements PipelineStep {
     // TODO: Make this open for extension,
     // so that user-land can configure multiple, arbitrary roles.
     if (this.requiresRole(navigationInstruction, OpenIdConnectRoles.Authenticated)) {
-      if (user === null) {
+      if (user === null || user.expired) {
         this.logger.debug('Requires authenticated role.');
 
         // capture the URL to which the user was originally navigating

--- a/test/open-id-connect-authorize-step.spec.ts
+++ b/test/open-id-connect-authorize-step.spec.ts
@@ -75,6 +75,15 @@ describe('open-id-connect-authorize-step', () => {
         sinon.assert.calledWithMatch(next.cancel, sinon.match.instanceOf(Redirect));
       });
 
+      it(`should redirect to ${unauthRedirectRoute} if user is expired`, async () => {
+        // arrange
+        (userManager.getUser).returns({ expired: true });
+        // act
+        await authorizationStep.run(navigationInstruction, next);
+        // assert
+        sinon.assert.calledWithMatch(next.cancel, sinon.match.instanceOf(Redirect));
+      });
+
       it(`redirect should be to the unauthorized route with original URL as LoginRedirect parameter`, async () => {
         // arrange
         (userManager.getUser).returns(null);
@@ -84,7 +93,7 @@ describe('open-id-connect-authorize-step', () => {
         sinon.assert.calledWith(next.cancel, new Redirect(expectedRedirect));
       });
 
-      it(`should NOT redirect to ${unauthRedirectRoute} if user is not null`, async () => {
+      it(`should NOT redirect to ${unauthRedirectRoute} if user is not null and not expired`, async () => {
         // arrange
         (userManager.getUser).returns({});
         // act


### PR DESCRIPTION
On occasion or when working offline, my user session expires yet the AuthorizeStep does not kick in and still allows me to navigate to protected routes.