### PR TITLE
Fixed issue with login expecting an instruction to be available

### DIFF
--- a/src/open-id-connect.ts
+++ b/src/open-id-connect.ts
@@ -27,11 +27,12 @@ export default class OpenIdConnect {
   }
 
   public async login(args: any = {}): Promise<void> {
-
-    const loginRedirectValue = this.router.currentInstruction.queryParams[LoginRedirectKey];
-    if (loginRedirectValue) {
-      args.data = { ...args.data };
-      args.data[LoginRedirectKey] = loginRedirectValue;
+    if (this.router.currentInstruction) {
+      const loginRedirectValue = this.router.currentInstruction.queryParams[LoginRedirectKey];
+      if (loginRedirectValue) {
+        args.data = { ...args.data };
+        args.data[LoginRedirectKey] = loginRedirectValue;
+      }
     }
 
     await this.userManager.signinRedirect(args);

--- a/test/open-id-connect.spec.ts
+++ b/test/open-id-connect.spec.ts
@@ -81,6 +81,15 @@ describe('open-id-connect', () => {
         },
       });
     });
+
+    it('should not care if currentInstruction is not yet available', async () => {
+      // arrange
+      router.currentInstruction = null;
+      // act
+      await openIdConnect.login();
+      // assert
+      sinon.assert.calledWith(userManager.signinRedirect, { });
+    });
   });
 
   context('logout', () => {


### PR DESCRIPTION
When aurelia-router was not used- or it was not yet initialize, openIdConnect.login would throw. e.g. in App.activate method (which runs before configureRouter).