### PR TITLE
Honor router root if configured

### DIFF
--- a/src/open-id-connect-routing.ts
+++ b/src/open-id-connect-routing.ts
@@ -34,7 +34,8 @@ export default class OpenIdConnectRouting {
           return this.openIdConnectNavigationStrategies.signInRedirectCallback(instruction);
         }
       },
-      route: this.getPath(this.openIdConnectConfiguration.redirectUri),
+      route: this.getPath(this.openIdConnectConfiguration.redirectUri)
+        .replace(routerConfiguration.options.root || '/', '/'),
     });
   }
 
@@ -44,7 +45,8 @@ export default class OpenIdConnectRouting {
       navigationStrategy: (instruction: NavigationInstruction) => {
         return this.openIdConnectNavigationStrategies.signOutRedirectCallback(instruction);
       },
-      route: this.getPath(this.openIdConnectConfiguration.postLogoutRedirectUri),
+      route: this.getPath(this.openIdConnectConfiguration.postLogoutRedirectUri)
+        .replace(routerConfiguration.options.root || '/', '/'),
     });
   }
 


### PR DESCRIPTION
The login and logout routes does not currently take into account the configuration of an alternate `root` on the router other than the default which is undefined. Say for example that the application runs with the root `/myapp/`. Then the added routes should be e.g. `/signin-oidc` and not `/myapp/signin-oidc`.